### PR TITLE
Add a systemd dependency

### DIFF
--- a/swayidle/swayidle.spec
+++ b/swayidle/swayidle.spec
@@ -13,6 +13,7 @@ BuildRequires:  clang
 BuildRequires:  meson
 BuildRequires:  wayland-devel
 BuildRequires:  wayland-protocols-devel
+BuildRequires:  systemd
 BuildRequires:  scdoc
 
 


### PR DESCRIPTION
Hey there,

I do not know if this is entirely correct, but swayidle is missing the `before-sleep` feature for me.
If I add the systemd dependency and build the package locally it is working all right.

Thank you
Nagua